### PR TITLE
Fix: Replace DbContext Singleton with proper disposal pattern

### DIFF
--- a/lab6/lab6/Models/MineSweeperDbContext.cs
+++ b/lab6/lab6/Models/MineSweeperDbContext.cs
@@ -11,21 +11,9 @@ namespace lab6.Models;
 public class MineSweeperDbContext : DbContext
 {
     public DbSet<User> Users => Set<User>();
+
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         optionsBuilder.UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=MinesweeperDb;Trusted_Connection=True;");
     }
-
-    private MineSweeperDbContext() : base() { }
-
-    public static MineSweeperDbContext Instance
-    { 
-        get
-        {
-            instance ??= new();
-            return instance;
-        } 
-    }
-    private static MineSweeperDbContext? instance;
-
 }

--- a/lab6/lab6/ViewModels/AuthVM.cs
+++ b/lab6/lab6/ViewModels/AuthVM.cs
@@ -12,52 +12,51 @@ namespace lab6.ViewModels;
 
 class AuthVM : Core.VMBase
 {
-	private string login = "";
-	private string password = "";
+    private string login = "";
+    private string password = "";
 
-	public RelayCommand AuthCmd { get; set; }
-	public AuthVM()
-	{
+    public RelayCommand AuthCmd { get; set; }
+    public AuthVM()
+    {
         AuthCmd = new RelayCommand(auth, canAuth);
-	}
+    }
 
-	public EventHandler<AuthEventArgs>? AuthHndl;
-	public EventHandler? RegisterHndl;
+    public EventHandler<AuthEventArgs>? AuthHndl;
+    public EventHandler? RegisterHndl;
 
-	private void auth(object? param)
-	{
-		var db = MineSweeperDbContext.Instance;
-		User? user = db.Users.FirstOrDefault(u => u.Login == Login);
-		if (user == null)
-		{
-			Login = "";
-			Password = "";
+    private void auth(object? param)
+    {
+        using var db = new MineSweeperDbContext();
+        User? user = db.Users.FirstOrDefault(u => u.Login == Login);
+        if (user == null)
+        {
+            Login = "";
+            Password = "";
             MessageBox.Show("User with specified login are not exist");
             return;
         }
-		if (user.Password != Password)
-		{
-			Password = "";
+        if (user.Password != Password)
+        {
+            Password = "";
             MessageBox.Show("Password are incorrect");
             return;
-		}
-		AuthHndl?.Invoke(this, new AuthEventArgs(user));
+        }
+        AuthHndl?.Invoke(this, new AuthEventArgs(user));
+    }
 
-	}
-	private bool canAuth(object? param) => login.Length >= 4 && password.Length >= 8;
-		
+    private bool canAuth(object? param) => login.Length >= 4 && password.Length >= 8;
 
-	public string Login
-	{
-		get => login; 
-		set 
-		{ 
-			login = value;
-			NotifyOnPropertyChanged();
-		}
-	}
-	public string Password
-	{
+    public string Login
+    {
+        get => login;
+        set
+        {
+            login = value;
+            NotifyOnPropertyChanged();
+        }
+    }
+    public string Password
+    {
         get => password;
         set
         {
@@ -65,11 +64,11 @@ class AuthVM : Core.VMBase
             NotifyOnPropertyChanged();
         }
     }
-	
-	public class AuthEventArgs : EventArgs
-	{
+
+    public class AuthEventArgs : EventArgs
+    {
         public User User { get; set; }
-		public AuthEventArgs(User user)
+        public AuthEventArgs(User user)
         {
             User = user;
         }

--- a/lab6/lab6/ViewModels/RegisterVM.cs
+++ b/lab6/lab6/ViewModels/RegisterVM.cs
@@ -11,66 +11,65 @@ namespace lab6.ViewModels;
 
 class RegisterVM : VMBase
 {
-	private string login = "";
-	private string password = "";
-	private string passwordConfirm = "";
+    private string login = "";
+    private string password = "";
+    private string passwordConfirm = "";
 
-	public RelayCommand RegisterCmd { get; set; }
+    public RelayCommand RegisterCmd { get; set; }
 
-	public EventHandler<RegisterEventsArgs>? RegisterHndl { get; set; }
-	public EventHandler? AuthHndl { get; set; }
+    public EventHandler<RegisterEventsArgs>? RegisterHndl { get; set; }
+    public EventHandler? AuthHndl { get; set; }
 
-	public RegisterVM()
-	{
-		RegisterCmd = new(register, canRegister);
-	}
-
-
-	private void register(object? param)
-	{
-		var db = MineSweeperDbContext.Instance;
-		User? user = db.Users.FirstOrDefault(u => u.Login == Login);
-		if (user != null)
-		{
-			Login = "";
-			Password = "";
-			PasswordConfirm = "";
-			MessageBox.Show("User login are taken");
-			return;
-        }
-		user = new User() { Login = Login, Password = Password };
-		db.Users.Add(user);
-		db.SaveChanges();
-		RegisterHndl?.Invoke(this, new RegisterEventsArgs(user));
-	}
-	private bool canRegister(object? param)
-	{
-		return Login.Length >= 4 && Password.Length >= 8 && Password == PasswordConfirm;
-	}
-
-    public string Login
-	{
-		get => login; 
-		set { login = value; NotifyOnPropertyChanged(); }
-	}
-	public string Password
-	{
-		get { return password; }
-		set { password = value; NotifyOnPropertyChanged(); }
-	}
-	public string PasswordConfirm
-	{
-		get { return passwordConfirm; }
-		set { passwordConfirm = value; NotifyOnPropertyChanged(); }
-	}
-
-	public class RegisterEventsArgs : EventArgs
-	{
-        public User User { get; set; }
-		public RegisterEventsArgs(User user)
-		{
-			User = user;
-		}
+    public RegisterVM()
+    {
+        RegisterCmd = new(register, canRegister);
     }
 
+    private void register(object? param)
+    {
+        using var db = new MineSweeperDbContext();
+        User? user = db.Users.FirstOrDefault(u => u.Login == Login);
+        if (user != null)
+        {
+            Login = "";
+            Password = "";
+            PasswordConfirm = "";
+            MessageBox.Show("User login are taken");
+            return;
+        }
+        user = new User() { Login = Login, Password = Password };
+        db.Users.Add(user);
+        db.SaveChanges();
+        RegisterHndl?.Invoke(this, new RegisterEventsArgs(user));
+    }
+
+    private bool canRegister(object? param)
+    {
+        return Login.Length >= 4 && Password.Length >= 8 && Password == PasswordConfirm;
+    }
+
+    public string Login
+    {
+        get => login;
+        set { login = value; NotifyOnPropertyChanged(); }
+    }
+    public string Password
+    {
+        get { return password; }
+        set { password = value; NotifyOnPropertyChanged(); }
+    }
+    public string PasswordConfirm
+    {
+        get { return passwordConfirm; }
+        set { passwordConfirm = value; NotifyOnPropertyChanged(); }
+    }
+
+    public class RegisterEventsArgs : EventArgs
+    {
+        public User User { get; set; }
+        public RegisterEventsArgs(User user)
+        {
+            User = user;
+        }
+    }
 }


### PR DESCRIPTION
Removed singleton pattern from MineSweeperDbContext (anti-pattern for EF)
Updated AuthVM and RegisterVM to use proper using statements for DbContext
Ensures proper resource cleanup and prevents memory leaks
Follows Entity Framework best practices for context lifetime management